### PR TITLE
Fix fallback response bug

### DIFF
--- a/frontend/app/chat/component/ChatClient.tsx
+++ b/frontend/app/chat/component/ChatClient.tsx
@@ -124,16 +124,19 @@ const ChatClient = () => {
           setThreadId(newThreadId);
         }
   
+        let aiText: string | undefined;
         if (primaryApiResponse) {
+          aiText = primaryApiResponse.response;
           const responseMessage: Message = {
             id: new Date().toISOString(),
-            text: primaryApiResponse.response,
+            text: aiText,
             sender: "Bot",
             timestamp: new Date().toISOString(),
           };
           setMessages((prevMessages) => [...prevMessages, responseMessage]);
         } else {
           const fallbackMessage = await callFallbackApi(messageInput);
+          aiText = fallbackMessage;
           const responseMessage: Message = {
             id: new Date().toISOString(),
             text: fallbackMessage,
@@ -142,7 +145,9 @@ const ChatClient = () => {
           };
           setMessages((prevMessages) => [...prevMessages, responseMessage]);
         }
-        setAiResponse(primaryApiResponse.response);
+        if (aiText !== undefined) {
+          setAiResponse(aiText);
+        }
       }
       setIsClicked(true)
     }


### PR DESCRIPTION
## Summary
- handle missing primary API response in chat client

## Testing
- `npm run lint`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6889551366748326acc264f0b5465c3d